### PR TITLE
fix: change sizing and padding according to fontscale and add fontscale slider

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,10 @@ import ScoreBoard from './components/ScoreBoard.vue'
 </script>
 
 <style>
+body {
+  line-height: 1 !important;
+}
+
 :root {
   --font-scale: 1;
 }

--- a/src/components/BoardSettings.vue
+++ b/src/components/BoardSettings.vue
@@ -29,12 +29,33 @@
         </div>
         <div class="row mb-3">
           <label class="col-sm-3 col-form-label text-end"> Font scale: </label>
-          <div class="col-sm-2">
-            <input type="number" step="0.1" min="0.5" max="2" class="form-control" v-model="fontScale" />
+          <div class="col-sm-3">
+            <input
+              class="mt-2"
+              style="width: 85%"
+              type="range"
+              min="0.5"
+              max="2"
+              step="0.1"
+              v-model="fontScale"
+            />
+            <label for="font-range" class="form-label ms-3">
+              {{ Math.round(fontScale * 100) }}%
+            </label>
           </div>
           <div class="col-sm-3">
-            <button class="btn btn-primary" @click.prevent="fontScale = Math.min(2, fontScale + 0.1)">+</button>
-            <button class="btn btn-primary" @click.prevent="fontScale = Math.max(0.5, fontScale - 0.1)">-</button>
+            <button
+              class="btn btn-primary"
+              @click.prevent="fontScale = Math.round(Math.min(2, fontScale + 0.1) * 10) / 10"
+            >
+              +
+            </button>
+            <button
+              class="btn btn-primary"
+              @click.prevent="fontScale = Math.round(Math.max(0.5, fontScale - 0.1) * 10) / 10"
+            >
+              -
+            </button>
           </div>
         </div>
         <h2>Score</h2>

--- a/src/components/MatchTimer.vue
+++ b/src/components/MatchTimer.vue
@@ -61,7 +61,10 @@ export default defineComponent({
     run() {
       this.running = true
       this.timer = getTimer(() => {
-        const { nextTimeInSeconds, shouldStop } = tickMatchTime(this.timeInSeconds, this.isCountdown)
+        const { nextTimeInSeconds, shouldStop } = tickMatchTime(
+          this.timeInSeconds,
+          this.isCountdown
+        )
         this.timeInSeconds = nextTimeInSeconds
         if (shouldStop) {
           this.stop()

--- a/src/components/ScoreBoard.vue
+++ b/src/components/ScoreBoard.vue
@@ -40,7 +40,6 @@
           :hideShido="hideShido"
         />
         <TimeBanner
-          :class="fontScale < 1.8 ? (fontScale < 1.3 ? 'pt-3' : 'pt-5') : ''"
           :key="maxTime"
           @reset="bout += 1"
           @resetAll="resetScore"
@@ -134,8 +133,6 @@ export default defineComponent({
     getPlayerBannerSize() {
       if (this.fontScale < 1.3) {
         return '35vh'
-      } else if (this.fontScale > 1.2 && this.fontScale < 1.8) {
-        return '30vh'
       } else {
         return ''
       }

--- a/src/components/ScoreBoard.vue
+++ b/src/components/ScoreBoard.vue
@@ -22,7 +22,7 @@
           :name="player1"
           :player="1"
           class="bg-white"
-          style="height: 35vh"
+          :style="'height: ' + getPlayerBannerSize"
           :useYuko="useYuko"
           :maxShidos="maxShidos"
           :hideShido="hideShido"
@@ -34,12 +34,13 @@
           :name="player2"
           :player="2"
           class="bg-danger"
-          style="height: 35vh"
+          :style="'height: ' + getPlayerBannerSize"
           :useYuko="useYuko"
           :maxShidos="maxShidos"
           :hideShido="hideShido"
         />
         <TimeBanner
+          :class="fontScale < 1.8 ? (fontScale < 1.3 ? 'pt-3' : 'pt-5') : ''"
           :key="maxTime"
           @reset="bout += 1"
           @resetAll="resetScore"
@@ -126,6 +127,17 @@ export default defineComponent({
         ;(this.$refs as any).timeBanner.goldenScore = false
         ;(this.$refs as any).timeBanner.maximumTime = this.maxTime
         this.onSettingsChange()
+      }
+    }
+  },
+  computed: {
+    getPlayerBannerSize() {
+      if (this.fontScale < 1.3) {
+        return '35vh'
+      } else if (this.fontScale > 1.2 && this.fontScale < 1.8) {
+        return '30vh'
+      } else {
+        return ''
       }
     }
   },

--- a/src/components/ScoreCounter.vue
+++ b/src/components/ScoreCounter.vue
@@ -16,8 +16,9 @@
     <div class="row">
       <div class="col d-flex justify-content-center">
         <h1
-          class="super-big"
-          :class="name === 'Shido' ? 'bg-warning text-danger border border-danger' : ''"
+          :class="
+            name === 'Shido' ? 'bg-warning text-danger border border-danger big' : 'super-big'
+          "
           @click="add()"
         >
           {{ count }}


### PR DESCRIPTION
- Added slider to change fontscale

Fontscale > 120% meant app would run out of screen, to fix:
- Change size of judo player banner based on fontscale
- Change padding in timer bar based on fontscale
- Change line height to 1 in whole app (only affects time banner, that's why padding above was required)