### PR TITLE
Add English and Dutch interface localization

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x, 24.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ src/utils/utils.js
 *.zip
 .yarn
 .yarn/**
+/.air/
+**/worktree.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Project
+
+Judo Score Board is a Vue 3 and TypeScript application that runs in browsers
+and as an Electron desktop app. The renderer is in `src/`; Electron-specific
+code is in `electron/`.
+
+## Commands
+
+```sh
+yarn dev              # Run the web development server
+yarn electron:dev     # Run Electron with hot reload
+yarn build            # Create a web production build
+yarn electron:build   # Package the Electron app
+yarn test             # Run all Jest tests
+yarn test <file>      # Run one test file, e.g. src/utils/goldenScore.test.ts
+yarn type-check       # Run vue-tsc
+yarn lint             # Run ESLint (automatically fixes files)
+yarn format           # Format src/ with Prettier
+```
+
+Run `yarn test` and `yarn type-check` after changing scoring or timer logic.
+Use `yarn lint` deliberately: its configured `--fix` changes files.
+
+## Architecture and conventions
+
+- `src/components/ScoreBoard.vue` is the central match-state orchestrator.
+  Child components communicate upward through Vue emits and are controlled
+  downward through template refs.
+- Keep independently testable rules in pure functions under `src/utils/`, with
+  adjacent Jest test files named `*.test.ts`.
+- `JudoPlayer.vue` enforces score rules: two waza-ari become an ippon, and the
+  configured maximum number of shidos makes that player lose.
+- `TimeBanner.vue` owns match and pin timer interactions, including golden
+  score. Golden score uses a 60-second reset timer; disabling it restores the
+  configured match duration.
+- `BoardSettings.vue` stores the timer strategy (`down` or `up`) in
+  `localStorage` under `judo-score:countdown`.
+- The `ELECTRON=true` environment variable switches Vite to Electron mode.
+  Keep changes compatible with both browser and Electron targets unless the
+  task explicitly limits one target.
+
+## Guardrails
+
+- Preserve the established Options API, emit, and `$refs` patterns in existing
+  components unless the task explicitly calls for a broader refactor.
+- Do not change keyboard shortcuts or scoring semantics without updating the
+  relevant help text and tests.
+- Avoid editing generated deployment assets in `docs/` unless the task is to
+  refresh the published web build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ To run a single test file:
 yarn test src/utils/goldenScore.test.ts
 ```
 
+Run `yarn test` and `yarn type-check` after changing scoring or timer logic.
+Use `yarn lint` deliberately: its configured `--fix` changes files.
+
 ## Architecture
 
 **Dual-target app:** the same Vue 3 codebase runs as a browser web app or as an Electron desktop app. The toggle is the `ELECTRON=true` env var, which `vite.config.ts` reads to conditionally load the `vite-plugin-electron` and `vite-plugin-electron-renderer` plugins. The Electron entry is `electron/main.ts`; the renderer is the standard Vue app.
@@ -50,9 +53,16 @@ App.vue
 - `TimeBanner.vue` (`keyup`): Tab/Control = toggle match timer, Shift = toggle pin timer, g/G = golden score, r/R = reset all, t/T = reset timer. Bindings are suppressed when settings panel is open.
 - `JudoPlayer.vue` (`keydown`): a/z = P1 ippon ±1, s/x = P1 waza-ari ±1, d/c = P1 yuko ±1; j/m = P2 ippon ±1, k/, = P2 waza-ari ±1, l/. = P2 yuko ±1.
 
-**Utilities (`src/utils/`):** pure functions extracted for testability. Jest tests cover `goldenScore.ts` and `matchTimerLogic.ts`. Vue components themselves are not tested.
+**Utilities (`src/utils/`):** pure functions extracted for testability, with adjacent Jest test files named `*.test.ts`. Jest tests cover `goldenScore.ts` and `matchTimerLogic.ts`. Vue components themselves are not tested.
 
 **localStorage:** `BoardSettings.vue` persists only the timer strategy (`'down'`/`'up'`) under the key `judo-score:countdown`.
+
+## Guardrails
+
+- Preserve the established Options API, emit, and `$refs` patterns in existing components unless the task explicitly calls for a broader refactor.
+- Do not change keyboard shortcuts or scoring semantics without updating the relevant help text and tests.
+- Keep changes compatible with both browser and Electron targets unless the task explicitly limits one target.
+- Avoid editing generated deployment assets in `docs/` unless the task is to refresh the published web build.
 
 ## Agent skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```sh
+yarn dev              # web dev server (browser only)
+yarn electron:dev     # Electron dev with hot reload
+yarn build            # web production build
+yarn electron:build   # Electron production build + package
+yarn test             # run Jest tests
+yarn lint             # ESLint with auto-fix
+yarn type-check       # vue-tsc type check
+yarn format           # Prettier on src/
+```
+
+To run a single test file:
+```sh
+yarn test src/utils/goldenScore.test.ts
+```
+
+## Architecture
+
+**Dual-target app:** the same Vue 3 codebase runs as a browser web app or as an Electron desktop app. The toggle is the `ELECTRON=true` env var, which `vite.config.ts` reads to conditionally load the `vite-plugin-electron` and `vite-plugin-electron-renderer` plugins. The Electron entry is `electron/main.ts`; the renderer is the standard Vue app.
+
+**Component tree:**
+
+```
+App.vue
+└── ScoreBoard.vue          ← central orchestrator, owns all match state
+    ├── TopBanner.vue       ← mat/message/bout display + nav buttons (Settings, Help, Break)
+    ├── BreakPage.vue       ← shown when match is paused (replaces players + timer)
+    ├── BoardSettings.vue   ← settings form; persists timer strategy to localStorage
+    ├── HelpPage.vue        ← key binding reference
+    ├── JudoPlayer.vue × 2 ← per-player scoring (Ippon, Waza-ari, Yuko, Shido)
+    │   └── ScoreCounter.vue
+    └── TimeBanner.vue      ← match + pin timer controls, golden score toggle
+        ├── MatchTimer.vue
+        └── PinningTimer.vue
+```
+
+**State flow:** `ScoreBoard.vue` holds all match state as `data()`. Settings are _not_ passed down as reactive props from the form — instead, `ScoreBoard` reads `this.$refs.settings.*` imperatively when the settings panel is saved (`onSettingsChange()`). Child-to-parent communication is via Vue `emits`; parent-to-child control is via `$refs` (e.g., `this.$refs.timeBanner.stopTimer()`).
+
+**Scoring rules encoded in components:**
+- `JudoPlayer.vue`: 2 waza-ari auto-converts to an ippon (calls `ScoreCounter.reset()` + `ippon.add()`); reaching `maxShidos` shidos emits `loses` (which makes the opponent win via `ScoreBoard`).
+- `TimeBanner.vue`: golden score sets timer to 60 s and resets; re-toggling restores `maxTime`.
+
+**Key bindings** are split across two components:
+- `TimeBanner.vue` (`keyup`): Tab/Control = toggle match timer, Shift = toggle pin timer, g/G = golden score, r/R = reset all, t/T = reset timer. Bindings are suppressed when settings panel is open.
+- `JudoPlayer.vue` (`keydown`): a/z = P1 ippon ±1, s/x = P1 waza-ari ±1, d/c = P1 yuko ±1; j/m = P2 ippon ±1, k/, = P2 waza-ari ±1, l/. = P2 yuko ±1.
+
+**Utilities (`src/utils/`):** pure functions extracted for testability. Jest tests cover `goldenScore.ts` and `matchTimerLogic.ts`. Vue components themselves are not tested.
+
+**localStorage:** `BoardSettings.vue` persists only the timer strategy (`'down'`/`'up'`) under the key `judo-score:countdown`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,17 @@ App.vue
 **Utilities (`src/utils/`):** pure functions extracted for testability. Jest tests cover `goldenScore.ts` and `matchTimerLogic.ts`. Vue components themselves are not tested.
 
 **localStorage:** `BoardSettings.vue` persists only the timer strategy (`'down'`/`'up'`) under the key `judo-score:countdown`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and specs are tracked in this repository's GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Uses the five default canonical triage labels. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Uses a single-context layout. See `docs/agents/domain.md`.

--- a/docs/adr/0001-vue-i18n-for-interface-localization.md
+++ b/docs/adr/0001-vue-i18n-for-interface-localization.md
@@ -1,3 +1,7 @@
 # Use Vue I18n for interface localization
 
-The scoreboard supports English and Dutch interface copy through Vue I18n, with TypeScript message catalogues. The active locale is an operator preference: use a persisted explicit choice when present, otherwise normalize the browser locale to `nl` or fall back to `en`; changing it updates interface copy without changing match state or operator-entered configuration. Japanese judo terms remain unchanged, while locale-owned defaults are translated only before an operator replaces them.
+The scoreboard supports English and Dutch interface copy through Vue I18n, with TypeScript message catalogues. The
+active locale is an operator preference: use a persisted explicit choice when present, otherwise normalize the browser
+locale to `nl` or fall back to `en`; changing it updates interface copy without changing match state or operator-entered
+configuration. Japanese judo terms remain unchanged, while locale-owned defaults are translated only before an operator
+replaces them.

--- a/docs/adr/0001-vue-i18n-for-interface-localization.md
+++ b/docs/adr/0001-vue-i18n-for-interface-localization.md
@@ -1,0 +1,3 @@
+# Use Vue I18n for interface localization
+
+The scoreboard supports English and Dutch interface copy through Vue I18n, with TypeScript message catalogues. The active locale is an operator preference: use a persisted explicit choice when present, otherwise normalize the browser locale to `nl` or fall back to `en`; changing it updates interface copy without changing match state or operator-entered configuration. Japanese judo terms remain unchanged, while locale-owned defaults are translated only before an operator replaces them.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package.json
+++ b/package.json
@@ -18,12 +18,15 @@
     "bootstrap": "5.3.3",
     "bootstrap-icons": "^1.11.3",
     "jest": "^29.7.0",
-    "vue": "^3.4.27"
+    "vue": "^3.5.0",
+    "vue-i18n": "11.1.12"
   },
   "devDependencies": {
+    "@intlify/devtools-types": "^11.4.8",
     "@rushstack/eslint-patch": "^1.8.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/node": "^20.12.7",
+    "@vue/compiler-sfc": "^3.5.0",
     "@vitejs/plugin-vue": "^5.0.4",
     "@vue/eslint-config-prettier": "^9.0.0",
     "@vue/eslint-config-typescript": "^13.0.0",

--- a/src/components/BoardSettings.vue
+++ b/src/components/BoardSettings.vue
@@ -3,32 +3,42 @@
     <div class="col">
       <div class="row">
         <div class="col-7">
-          <h1>Settings</h1>
+          <h1>{{ $t('settings.title') }}</h1>
         </div>
         <div class="col"></div>
       </div>
       <form>
-        <h2>General</h2>
+        <h2>{{ $t('settings.general') }}</h2>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Mat: </label>
+          <label class="col-sm-3 col-form-label text-end" for="locale">{{ $t('settings.language') }}:</label>
+          <div class="col-sm-3">
+            <select id="locale" class="form-select" v-model="localePreference" @change="changeLocale">
+              <option value="auto">{{ $t('settings.automatic') }}</option>
+              <option value="en">{{ $t('settings.english') }}</option>
+              <option value="nl">{{ $t('settings.dutch') }}</option>
+            </select>
+          </div>
+        </div>
+        <div class="row mb-3">
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.mat') }}: </label>
           <div class="col-sm-3">
             <input type="string" class="form-control" v-model="mat" />
           </div>
         </div>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Bout name: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.boutName') }}: </label>
           <div class="col-sm-3">
             <input type="string" class="form-control" v-model="boutTxt" />
           </div>
         </div>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Welcome message: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.welcomeMessage') }}: </label>
           <div class="col-sm-3">
             <input type="string" class="form-control" v-model="msg" />
           </div>
         </div>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Font scale: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.fontScale') }}: </label>
           <div class="col-sm-2">
             <input type="number" step="0.1" min="0.5" max="2" class="form-control" v-model="fontScale" />
           </div>
@@ -37,59 +47,59 @@
             <button class="btn btn-primary" @click.prevent="fontScale = Math.max(0.5, fontScale - 0.1)">-</button>
           </div>
         </div>
-        <h2>Score</h2>
+        <h2>{{ $t('settings.score') }}</h2>
         <div class="row">
           <div class="col-3"></div>
           <div class="form-check col-3">
             <input class="form-check-input" type="checkbox" id="yuko" v-model="yuko" />
-            <label class="form-check-label" for="yuko"> Add yuko </label>
+            <label class="form-check-label" for="yuko"> {{ $t('settings.addYuko') }} </label>
           </div>
         </div>
         <div class="row">
           <div class="col-3"></div>
           <div class="form-check col-3">
             <input class="form-check-input" type="checkbox" id="hideShido" v-model="hideShido" />
-            <label class="form-check-label" for="hideShido"> Hide shido </label>
+            <label class="form-check-label" for="hideShido"> {{ $t('settings.hideShido') }} </label>
           </div>
         </div>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Max number of shido's: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.maxShidos') }}: </label>
           <div class="col-sm-3">
             <input type="number" class="form-control" v-model="maxShidos" :disabled="hideShido" />
           </div>
         </div>
-        <h2>Players</h2>
+        <h2>{{ $t('settings.players') }}</h2>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Player 1 name: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.playerOne') }}: </label>
           <div class="col-sm-3">
             <input type="string" class="form-control" v-model="p1" />
           </div>
         </div>
         <!-- colour of players -->
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Player 2 name: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.playerTwo') }}: </label>
           <div class="col-sm-3">
             <input type="string" class="form-control" v-model="p2" />
           </div>
         </div>
-        <h2>Time</h2>
+        <h2>{{ $t('settings.time') }}</h2>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Max time: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.maxTime') }}: </label>
           <div class="col-sm-2">
             <input type="number" class="form-control" v-model="maxMatchTime" />
           </div>
-          <div class="col-sm-1">{{ convertSecondsToMinutes(maxMatchTime) }} min</div>
+          <div class="col-sm-1">{{ convertSecondsToMinutes(maxMatchTime) }} {{ $t('settings.minutes') }}</div>
           <div class="col-sm-3">
             <button class="btn btn-primary" @click.prevent="maxMatchTime += 60">+ 1 min</button>
             <button class="btn btn-primary" @click.prevent="maxMatchTime -= 60">- 1 min</button>
           </div>
         </div>
         <div class="row mb-3">
-          <label class="col-sm-3 col-form-label text-end"> Max pin time: </label>
+          <label class="col-sm-3 col-form-label text-end"> {{ $t('settings.maxPinTime') }}: </label>
           <div class="col-sm-2">
             <input type="number" class="form-control" v-model="maxPinTime" />
           </div>
-          <div class="col-sm-1">sec</div>
+          <div class="col-sm-1">{{ $t('settings.seconds') }}</div>
         </div>
         <div class="row">
           <div class="col-3"></div>
@@ -100,7 +110,7 @@
               id="ipponStopsTime"
               v-model="ipponStopsTime"
             />
-            <label class="form-check-label" for="ipponStopsTime"> Ippon stops time </label>
+            <label class="form-check-label" for="ipponStopsTime"> {{ $t('settings.ipponStopsTime') }} </label>
           </div>
         </div>
         <div class="row">
@@ -108,7 +118,7 @@
           <div class="col-3">
             <br />
             <form>
-              <div class="mb-1 fw-semibold">Age group / timer strategy</div>
+              <div class="mb-1 fw-semibold">{{ $t('settings.timerStrategy') }}</div>
               <div class="form-check">
                 <input
                   class="form-check-input"
@@ -119,7 +129,7 @@
                   v-model="countdown"
                 />
                 <label class="form-check-label" for="flexRadioDefault1">
-                  13- (count down from max time)
+                  {{ $t('settings.countdown') }}
                 </label>
               </div>
               <div class="form-check">
@@ -132,7 +142,7 @@
                   v-model="countdown"
                 />
                 <label class="form-check-label" for="flexRadioDefault2">
-                  13+ (count up from 0 until stopped)
+                  {{ $t('settings.countup') }}
                 </label>
               </div>
             </form>
@@ -140,7 +150,7 @@
         </div>
       </form>
       <button class="btn btn-primary" @click.prevent="$emit('saveSettings')">
-        <i class="bi bi-floppy-fill"></i> Save
+        <i class="bi bi-floppy-fill"></i> {{ $t('settings.save') }}
       </button>
     </div>
     <!-- <div class="col">
@@ -159,6 +169,7 @@
 <script lang="ts">
 import { convertSecondsToMinutes } from '@/utils/utils'
 import { defineComponent } from 'vue'
+import { getLocalePreference, setLocalePreference, type LocalePreference } from '@/i18n'
 
 const COUNTDOWN_STORAGE_KEY = 'judo-score:countdown'
 
@@ -166,7 +177,10 @@ export default defineComponent({
   name: 'BoardSettings',
   emits: ['saveSettings'],
   methods: {
-    convertSecondsToMinutes
+    convertSecondsToMinutes,
+    changeLocale() {
+      setLocalePreference(this.localePreference)
+    }
   },
   created() {
     const stored = window.localStorage.getItem(COUNTDOWN_STORAGE_KEY)
@@ -184,20 +198,21 @@ export default defineComponent({
   data() {
     return {
       countdown: 'down',
+      localePreference: getLocalePreference() as LocalePreference,
       maxMatchTime: 120,
       maxPinTime: 20,
       maxShidos: 3,
-      p1: 'Player 1',
-      p2: 'Player 2',
+      p1: this.$t('defaults.playerOne'),
+      p2: this.$t('defaults.playerTwo'),
       colP1: 'white',
       colP2: 'red',
-      msg: 'Yuseigachi Norg',
-      mat: 'Mat 1',
-      boutTxt: 'Ronde',
+      mat: this.$t('defaults.mat'),
+      boutTxt: this.$t('defaults.boutName'),
       fontScale: 1,
       ipponStopsTime: true,
       yuko: true,
-      hideShido: false
+      hideShido: false,
+      msg: this.$t('defaults.welcomeMessage')
     }
   }
 })

--- a/src/components/HelpPage.vue
+++ b/src/components/HelpPage.vue
@@ -1,87 +1,82 @@
 <template>
   <div class="row">
     <div class="col">
-      <h1>About</h1>
-      This tool was created by
-      <a href="https://github.com/marikaris" taret="_blank">MariKariS</a>
-      under
-      <a href="https://github.com/marikaris/judo-score?tab=MIT-1-ov-file" taret="_blank"
+      <h1>{{ $t('help.about') }}</h1>
+      {{ $t('help.intro') }}
+      <a href="https://github.com/marikaris" target="_blank">MariKariS</a>
+      {{ $t('help.under') }}
+      <a href="https://github.com/marikaris/judo-score?tab=MIT-1-ov-file" target="_blank"
         >MIT licence</a
-      >. It is free to use as score board for judo competitions, without any warranty. Developer is
-      not responsible for any bugs. If you do however encounter an issue, please submit it to the
-      <a href="https://github.com/marikaris/judo-score/issues" taret="_blank">GitHub issue page</a>.
-      Source code can be found on
-      <a href="https://github.com/marikaris/judo-score/" taret="_blank">GitHub</a>.
+      >.
+      {{ $t('help.licenceDescription') }}
+      <a href="https://github.com/marikaris/judo-score/issues" target="_blank">{{ $t('help.issuePage') }}</a>.
+      {{ $t('help.source') }}
+      <a href="https://github.com/marikaris/judo-score/" target="_blank">GitHub</a>.
     </div>
     <div class="row mt-4">
       <div class="col">
-        <h1>Timer modes (age groups)</h1>
+        <h1>{{ $t('help.timerModes') }}</h1>
         <p>
-          In <b>Settings → Time</b> you can select the timer strategy. This setting is stored and
-          will stay the same until you change it again.
+          {{ $t('help.timerModeDescription') }}
         </p>
         <ul>
-          <li><b>13-</b>: counts down from the configured <b>Max time</b> to <b>00:00</b> and stops.</li>
-          <li><b>13+</b>: counts up from <b>00:00</b> until you stop the timer.</li>
+          <li><b>13-</b>: {{ $t('help.countdownDescription') }}</li>
+          <li><b>13+</b>: {{ $t('help.countupDescription') }}</li>
         </ul>
       </div>
     </div>
     <div class="row">
       <div class="col">
-        <h1 style="padding-top: 25px;">Key bindings</h1>
-        To make use of the tool easier, a couple keys are bound to functions in the tool. See the
-        table below for all available key bindings:
+        <h1 style="padding-top: 25px;">{{ $t('help.keyBindings') }}</h1>
+        {{ $t('help.keyBindingsDescription') }}
         <div class="row g-3 align-items-start">
           <div class="col-12 col-lg-6">
             <table class="table">
               <tr>
-                <th>Key</th>
-                <th>Function</th>
+                <th>{{ $t('help.key') }}</th>
+                <th>{{ $t('help.function') }}</th>
               </tr>
               <tr>
                 <td>Tab, Control</td>
-                <td>Run timer</td>
+                <td>{{ $t('help.runTimer') }}</td>
               </tr>
               <tr>
                 <td>Shift</td>
-                <td>Run pin timer</td>
+                <td>{{ $t('help.runPinTimer') }}</td>
               </tr>
               <tr>
                 <td>r, R</td>
-                <td>Refresh all</td>
+                <td>{{ $t('help.refreshAll') }}</td>
               </tr>
               <tr>
                 <td>t, T</td>
-                <td>Refresh timers</td>
+                <td>{{ $t('help.refreshTimers') }}</td>
               </tr>
               <tr>
                 <td>g, G</td>
-                <td>Golden score</td>
+                <td>{{ $t('timer.goldenScore') }}</td>
               </tr>
             </table>
           </div>
           <div class="col-12 col-lg-6 d-flex justify-content-center">
             <img
               :src="keyboardSvg"
-              alt="Keyboard layout for player key bindings"
+              :alt="$t('help.keyboardLayout')"
               class="img-fluid"
               style="max-width: 600px; width: 100%"
             />
           </div>
         </div>
 
-        <h2>Add/Subtract scoring (keyboard)</h2>
-        <p>
-          Each player has dedicated keys for increasing (+) and decreasing (−) their scores. These
-          keys mirror the +/- buttons on the scoreboard and follow the rules below.
-        </p>
+        <h2>{{ $t('help.scoringKeyboard') }}</h2>
+        <p>{{ $t('help.scoringKeyboardDescription') }}</p>
         <div class="row">
           <div class="col-md-6">
-            <h3>Player 1</h3>
+            <h3>{{ $t('help.playerOne') }}</h3>
             <table class="table">
               <tr>
-                <th>Key</th>
-                <th>Result</th>
+                <th>{{ $t('help.key') }}</th>
+                <th>{{ $t('help.result') }}</th>
               </tr>
               <tr>
                 <td>a, A</td>
@@ -110,11 +105,11 @@
             </table>
           </div>
           <div class="col-md-6">
-            <h3>Player 2</h3>
+            <h3>{{ $t('help.playerTwo') }}</h3>
             <table class="table">
               <tr>
-                <th>Key</th>
-                <th>Result</th>
+                <th>{{ $t('help.key') }}</th>
+                <th>{{ $t('help.result') }}</th>
               </tr>
               <tr>
                 <td>j, J</td>
@@ -144,22 +139,13 @@
           </div>
         </div>
 
-        <h2>Scoring rules for additions and subtractions</h2>
+        <h2>{{ $t('help.scoringRules') }}</h2>
         <ul>
-          <li>Scores cannot go below 0. Subtracting at 0 has no effect.</li>
-          <li>
-            Two Waza-ari automatically convert to one Ippon (the Waza-ari counter resets to 0 and
-            Ippon increases by 1).
-          </li>
-          <li>
-            When a player receives an Ippon, they immediately win the match. If the setting
-            “Ippon stops time” is enabled, the match timer is stopped automatically.
-          </li>
-          <li>
-            Yuko can be disabled in Settings. When disabled, Yuko values are hidden and related key
-            bindings are ignored.
-          </li>
-          <li>You can also use the on-screen + / − buttons to change each score.</li>
+          <li>{{ $t('help.scoreCannotBeNegative') }}</li>
+          <li>{{ $t('help.twoWazaAri') }}</li>
+          <li>{{ $t('help.ipponWins') }}</li>
+          <li>{{ $t('help.yukoDisabled') }}</li>
+          <li>{{ $t('help.onScreenControls') }}</li>
         </ul>
       </div>
     </div>

--- a/src/components/PinningTimer.vue
+++ b/src/components/PinningTimer.vue
@@ -24,9 +24,9 @@
               <i class="bi bi-arrow-clockwise" @click="clearPrev"></i>
             </button>
           </div>
-          <div class="col">History:</div>
+          <div class="col">{{ $t('timer.history') }}:</div>
         </div>
-        <div class="ps-5" v-for="pin in prevPinnings" :key="pin">{{ pin }} sec</div>
+        <div class="ps-5" v-for="pin in prevPinnings" :key="pin">{{ pin }} {{ $t('settings.seconds') }}</div>
       </div>
     </div>
   </div>

--- a/src/components/TimeBanner.vue
+++ b/src/components/TimeBanner.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="row" :class="goldenScore ? 'bg-warning' : ''">
     <div class="col-3">
-      <div class="btn-group-vertical pt-5" role="group" aria-label="Vertical button group">
+      <div class="btn-group-vertical pt-5" role="group" :aria-label="$t('timer.controls')">
         <button class="btn btn-primary text-start" @click="resetTime">
-          <i class="bi bi-arrow-clockwise"></i> Reset timer
+          <i class="bi bi-arrow-clockwise"></i> {{ $t('timer.resetTimer') }}
         </button>
         <button class="btn btn-primary text-start" @click="resetAll">
-          <i class="bi bi-arrow-clockwise"></i> Reset all
+          <i class="bi bi-arrow-clockwise"></i> {{ $t('timer.resetAll') }}
         </button>
         <button
           class="btn text-start"
           :class="goldenScore ? 'btn-outline-dark' : 'btn-warning'"
           @click="runGoldenScore"
         >
-          <i class="bi bi-trophy-fill"></i> Golden score
+          <i class="bi bi-trophy-fill"></i> {{ $t('timer.goldenScore') }}
         </button>
       </div>
     </div>
@@ -28,7 +28,7 @@
         v-show="!goldenScore"
         class="btn-group-vertical"
         role="group"
-        aria-label="Vertical radio toggle button group"
+        :aria-label="$t('timer.playerSelector')"
       >
         <input
           type="radio"

--- a/src/components/TopBanner.vue
+++ b/src/components/TopBanner.vue
@@ -11,16 +11,16 @@
     </div>
     <div class="col">
       <button class="btn btn-link float-end" @click="toggleHelp">
-        <span v-if="helpOpen"><i class="bi bi-x-lg"></i> Close</span>
-        <span v-else><i class="bi bi-question-diamond-fill"></i> Help</span>
+        <span v-if="helpOpen"><i class="bi bi-x-lg"></i> {{ $t('navigation.close') }}</span>
+        <span v-else><i class="bi bi-question-diamond-fill"></i> {{ $t('navigation.help') }}</span>
       </button>
       <button class="btn btn-link float-end" @click="toggleSettings">
-        <span v-if="settingsOpen"><i class="bi bi-x-lg"></i> Close</span>
-        <span v-else><i class="bi bi-gear-fill"></i> Settings</span>
+        <span v-if="settingsOpen"><i class="bi bi-x-lg"></i> {{ $t('navigation.close') }}</span>
+        <span v-else><i class="bi bi-gear-fill"></i> {{ $t('navigation.settings') }}</span>
       </button>
       <button class="btn btn-link float-end" @click="toggleResume">
-        <span v-if="resumeMatch"><i class="bi bi-pause-fill"></i> Break</span>
-        <span v-else><i class="bi bi-play-fill"></i> Resume</span>
+        <span v-if="resumeMatch"><i class="bi bi-pause-fill"></i> {{ $t('navigation.break') }}</span>
+        <span v-else><i class="bi bi-play-fill"></i> {{ $t('navigation.resume') }}</span>
       </button>
     </div>
   </div>
@@ -54,7 +54,7 @@ export default defineComponent({
     }
   },
   props: {
-    boutName: { type: String, default: 'Ronde' },
+    boutName: { type: String, default: '' },
     bout: Number,
     message: String,
     mat: String

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+  detectBrowserLocale,
+  getLocalePreference,
+  localeForPreference,
+  messages,
+  normalizeLocale
+} from './index'
+
+function messageKeys(messages: Record<string, unknown>, prefix = ''): string[] {
+  return Object.entries(messages).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key
+    return typeof value === 'object' && value !== null
+      ? messageKeys(value as Record<string, unknown>, path)
+      : [path]
+  })
+}
+
+describe('locale selection', () => {
+  test('normalizes Dutch browser locales and falls back to English', () => {
+    expect(normalizeLocale('nl-NL')).toBe('nl')
+    expect(normalizeLocale('NL-be')).toBe('nl')
+    expect(normalizeLocale('de-DE')).toBe('en')
+    expect(normalizeLocale(undefined)).toBe('en')
+  })
+
+  test('uses the first browser language for automatic selection', () => {
+    expect(detectBrowserLocale(['nl-BE', 'en-US'])).toBe('nl')
+    expect(detectBrowserLocale(['fr-FR', 'nl-NL'])).toBe('en')
+    expect(localeForPreference('en', ['nl-NL'])).toBe('en')
+    expect(localeForPreference('auto', ['nl-NL'])).toBe('nl')
+  })
+
+  test('only accepts explicit supported locale preferences from storage', () => {
+    const storage = { getItem: () => 'nl' } as unknown as Storage
+    expect(getLocalePreference(storage)).toBe('nl')
+    expect(getLocalePreference({ getItem: () => 'de' } as unknown as Storage)).toBe('auto')
+  })
+})
+
+test('English and Dutch catalogues expose the same message keys', () => {
+  expect(messageKeys(messages.en).sort()).toEqual(messageKeys(messages.nl).sort())
+})

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,99 @@
+import { createI18n } from 'vue-i18n'
+
+export const LOCALE_STORAGE_KEY = 'judo-score:locale'
+export const supportedLocales = ['en', 'nl'] as const
+
+export type SupportedLocale = (typeof supportedLocales)[number]
+export type LocalePreference = SupportedLocale | 'auto'
+
+export const messages = {
+  en: {
+    defaults: {
+      mat: 'Mat 1',
+      boutName: 'Round',
+      playerOne: 'Player 1',
+      playerTwo: 'Player 2',
+      welcomeMessage: 'Yuseigachi Norg'
+    },
+    navigation: { close: 'Close', help: 'Help', settings: 'Settings', break: 'Break', resume: 'Resume' },
+    settings: {
+      title: 'Settings', general: 'General', language: 'Language', automatic: 'Automatic (browser language)',
+      english: 'English', dutch: 'Nederlands', mat: 'Mat', boutName: 'Bout name', welcomeMessage: 'Welcome message',
+      fontScale: 'Font scale', score: 'Score', addYuko: 'Add yuko', hideShido: 'Hide shido', maxShidos: 'Maximum number of shidos',
+      players: 'Players', playerOne: 'Player 1 name', playerTwo: 'Player 2 name', time: 'Time', maxTime: 'Maximum time',
+      minutes: 'min', maxPinTime: 'Maximum pin time', seconds: 'sec', ipponStopsTime: 'Ippon stops time',
+      timerStrategy: 'Age group / timer strategy', countdown: '13- (count down from maximum time)', countup: '13+ (count up from 0 until stopped)', save: 'Save'
+    },
+    timer: { resetTimer: 'Reset timer', resetAll: 'Reset all', goldenScore: 'Golden score', controls: 'Timer controls', playerSelector: 'Player selector', history: 'History' },
+    help: {
+      about: 'About', intro: 'This tool was created by', under: 'under', licenceDescription: 'It is free to use as a scoreboard for judo competitions, without any warranty. The developer is not responsible for any bugs. If you encounter an issue, please submit it on the', issuePage: 'GitHub issue page', source: 'Source code can be found on',
+      timerModes: 'Timer modes (age groups)', timerModeDescription: 'In Settings → Time you can select the timer strategy. This setting is stored and remains the same until you change it again.', countdownDescription: 'counts down from the configured maximum time to 00:00 and stops.', countupDescription: 'counts up from 00:00 until you stop the timer.', keyBindings: 'Key bindings', keyBindingsDescription: 'To make the tool easier to use, several keys are bound to functions. See the table below for all available key bindings:', key: 'Key', function: 'Function', runTimer: 'Run timer', runPinTimer: 'Run pin timer', refreshAll: 'Refresh all', refreshTimers: 'Refresh timers', keyboardLayout: 'Keyboard layout for player key bindings', scoringKeyboard: 'Add/subtract scoring (keyboard)', scoringKeyboardDescription: 'Each player has dedicated keys for increasing (+) and decreasing (−) their scores. These keys mirror the +/− buttons on the scoreboard and follow the rules below.', playerOne: 'Player 1', playerTwo: 'Player 2', result: 'Result', scoringRules: 'Scoring rules for additions and subtractions', scoreCannotBeNegative: 'Scores cannot go below 0. Subtracting at 0 has no effect.', twoWazaAri: 'Two Waza-ari automatically convert to one Ippon (the Waza-ari counter resets to 0 and the Ippon counter increases by 1).', ipponWins: 'When a player receives an Ippon, they immediately win the match. If the setting “Ippon stops time” is enabled, the match timer is stopped automatically.', yukoDisabled: 'Yuko can be disabled in Settings. When disabled, Yuko values are hidden and related key bindings are ignored.', onScreenControls: 'You can also use the on-screen + / − buttons to change each score.'
+    }
+  },
+  nl: {
+    defaults: {
+      mat: 'Mat 1',
+      boutName: 'Ronde',
+      playerOne: 'Speler 1',
+      playerTwo: 'Speler 2',
+      welcomeMessage: 'Yuseigachi Norg'
+    },
+    navigation: { close: 'Sluiten', help: 'Help', settings: 'Instellingen', break: 'Pauze', resume: 'Hervatten' },
+    settings: {
+      title: 'Instellingen', general: 'Algemeen', language: 'Taal', automatic: 'Automatisch (browsertaal)',
+      english: 'English', dutch: 'Nederlands', mat: 'Mat', boutName: 'Rondenaam', welcomeMessage: 'Welkomstbericht',
+      fontScale: 'Tekstgrootte', score: 'Score', addYuko: 'Yuko toevoegen', hideShido: 'Shido verbergen', maxShidos: 'Maximumaantal shido’s',
+      players: 'Spelers', playerOne: 'Naam speler 1', playerTwo: 'Naam speler 2', time: 'Tijd', maxTime: 'Maximumtijd',
+      minutes: 'min', maxPinTime: 'Maximale houdtijd', seconds: 'sec', ipponStopsTime: 'Ippon stopt de tijd',
+      timerStrategy: 'Leeftijdsgroep / timerstrategie', countdown: '13- (aftellen vanaf maximumtijd)', countup: '13+ (optellen vanaf 0 tot gestopt)', save: 'Opslaan'
+    },
+    timer: { resetTimer: 'Timer resetten', resetAll: 'Alles resetten', goldenScore: 'Golden score', controls: 'Timerbediening', playerSelector: 'Spelerkiezer', history: 'Geschiedenis' },
+    help: {
+      about: 'Over', intro: 'Deze tool is gemaakt door', under: 'onder de', licenceDescription: 'Hij is gratis te gebruiken als scorebord voor judowedstrijden, zonder enige garantie. De ontwikkelaar is niet verantwoordelijk voor bugs. Meld een probleem op de', issuePage: 'GitHub-pagina voor problemen', source: 'De broncode staat op',
+      timerModes: 'Timermodi (leeftijdsgroepen)', timerModeDescription: 'In Instellingen → Tijd kun je de timerstrategie kiezen. Deze instelling wordt opgeslagen en blijft gelijk totdat je hem wijzigt.', countdownDescription: 'telt af vanaf de ingestelde maximumtijd tot 00:00 en stopt.', countupDescription: 'telt op vanaf 00:00 totdat je de timer stopt.', keyBindings: 'Sneltoetsen', keyBindingsDescription: 'Om de tool makkelijker te gebruiken, zijn verschillende toetsen aan functies gekoppeld. Zie de tabel hieronder voor alle sneltoetsen:', key: 'Toets', function: 'Functie', runTimer: 'Timer starten', runPinTimer: 'Houdtimer starten', refreshAll: 'Alles resetten', refreshTimers: 'Timers resetten', keyboardLayout: 'Toetsenbordindeling voor sneltoetsen van spelers', scoringKeyboard: 'Score toevoegen/aftrekken (toetsenbord)', scoringKeyboardDescription: 'Elke speler heeft eigen toetsen om scores te verhogen (+) en te verlagen (−). Deze toetsen werken hetzelfde als de +/−-knoppen op het scorebord en volgen de regels hieronder.', playerOne: 'Speler 1', playerTwo: 'Speler 2', result: 'Resultaat', scoringRules: 'Regels voor score toevoegen en aftrekken', scoreCannotBeNegative: 'Scores kunnen niet lager dan 0 worden. Aftrekken bij 0 heeft geen effect.', twoWazaAri: 'Twee Waza-ari worden automatisch één Ippon (de Waza-ari-teller wordt 0 en de Ippon-teller neemt met 1 toe).', ipponWins: 'Wanneer een speler een Ippon krijgt, wint die speler onmiddellijk de wedstrijd. Als “Ippon stopt de tijd” is ingeschakeld, stopt de wedstrijdtimer automatisch.', yukoDisabled: 'Yuko kan worden uitgeschakeld in Instellingen. Dan worden Yuko-waarden verborgen en worden gerelateerde sneltoetsen genegeerd.', onScreenControls: 'Je kunt ook de + / −-knoppen op het scherm gebruiken om elke score te wijzigen.'
+    }
+  }
+} as const
+
+export function normalizeLocale(locale: string | undefined): SupportedLocale {
+  return locale?.toLowerCase().startsWith('nl') ? 'nl' : 'en'
+}
+
+export function detectBrowserLocale(languages: readonly string[] | undefined = typeof navigator === 'undefined' ? undefined : navigator.languages): SupportedLocale {
+  return normalizeLocale(languages?.[0])
+}
+
+export function getLocalePreference(storage: Storage | undefined = typeof window === 'undefined' ? undefined : window.localStorage): LocalePreference {
+  const stored = storage?.getItem(LOCALE_STORAGE_KEY)
+  return stored === 'en' || stored === 'nl' ? stored : 'auto'
+}
+
+export function localeForPreference(preference: LocalePreference, languages?: readonly string[]): SupportedLocale {
+  return preference === 'auto' ? detectBrowserLocale(languages) : preference
+}
+
+const initialLocale = localeForPreference(getLocalePreference())
+
+export const i18n = createI18n({
+  legacy: true,
+  globalInjection: true,
+  locale: initialLocale,
+  fallbackLocale: 'en',
+  messages
+})
+
+if (typeof document !== 'undefined') {
+  document.documentElement.lang = initialLocale
+}
+
+export function setLocalePreference(preference: LocalePreference) {
+  if (preference === 'auto') {
+    window.localStorage.removeItem(LOCALE_STORAGE_KEY)
+  } else {
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, preference)
+  }
+  i18n.global.locale = localeForPreference(preference)
+  if (typeof document !== 'undefined') {
+    document.documentElement.lang = i18n.global.locale
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import { i18n } from './i18n'
 
 import "bootstrap/scss/bootstrap.scss";
 import "bootstrap-icons/font/bootstrap-icons.css";
 
-createApp(App).mount('#app')
+createApp(App).use(i18n).mount('#app')

--- a/yarn.lock
+++ b/yarn.lock
@@ -148,10 +148,20 @@
   resolved "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz"
   integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
 
+"@babel/helper-string-parser@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
+  integrity sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==
+
 "@babel/helper-validator-identifier@^7.27.1", "@babel/helper-validator-identifier@^7.28.5":
   version "7.28.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz"
   integrity sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==
+
+"@babel/helper-validator-identifier@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz#bd87084ced0c796ec46bda492de6e83d29e89fc2"
+  integrity sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==
 
 "@babel/helper-validator-option@^7.27.1":
   version "7.27.1"
@@ -172,6 +182,13 @@
   integrity sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==
   dependencies:
     "@babel/types" "^7.28.5"
+
+"@babel/parser@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.8.tgz#9653716a2f10c677b98fbc63d4bfb000c302cf17"
+  integrity sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==
+  dependencies:
+    "@babel/types" "^7.29.8"
 
 "@babel/plugin-proposal-decorators@^7.23.0":
   version "7.28.0"
@@ -349,6 +366,14 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@babel/types@^7.29.8":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
+  integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
@@ -519,6 +544,57 @@
   version "2.0.3"
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
+
+"@intlify/core-base@11.1.12":
+  version "11.1.12"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.1.12.tgz#e02529021a4e69f8a1adcca5ce61963c71cd72ba"
+  integrity sha512-whh0trqRsSqVLNEUCwU59pyJZYpU8AmSWl8M3Jz2Mv5ESPP6kFh4juas2NpZ1iCvy7GlNRffUD1xr84gceimjg==
+  dependencies:
+    "@intlify/message-compiler" "11.1.12"
+    "@intlify/shared" "11.1.12"
+
+"@intlify/core-base@11.4.8":
+  version "11.4.8"
+  resolved "https://registry.yarnpkg.com/@intlify/core-base/-/core-base-11.4.8.tgz#1cbb60e2cad25a88a7db8896f6d5652c9792c16e"
+  integrity sha512-A+Q7SKm5oEcy1E/cghqd7n/St4XjTqLhiiyDuieNcMrJcrHlkY5n0jp7Q9dD3txvVHzvsmBVV5M9wD5/s1zfzw==
+  dependencies:
+    "@intlify/devtools-types" "11.4.8"
+    "@intlify/message-compiler" "11.4.8"
+    "@intlify/shared" "11.4.8"
+
+"@intlify/devtools-types@11.4.8", "@intlify/devtools-types@^11.4.8":
+  version "11.4.8"
+  resolved "https://registry.yarnpkg.com/@intlify/devtools-types/-/devtools-types-11.4.8.tgz#c71d284e218159aa11eaae4ec9166f15fc21fb37"
+  integrity sha512-MGpID+rlfzGUbNcnC20bm5NMSBHPrvx0atLTfv9dftn3kjXw1hGKDcIcwrO99tSrZEc2i+hczRL7ks8qXsHPkQ==
+  dependencies:
+    "@intlify/core-base" "11.4.8"
+    "@intlify/shared" "11.4.8"
+
+"@intlify/message-compiler@11.1.12":
+  version "11.1.12"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.1.12.tgz#27e69790b711a92cddb07175187dd09a7b270b55"
+  integrity sha512-Fv9iQSJoJaXl4ZGkOCN1LDM3trzze0AS2zRz2EHLiwenwL6t0Ki9KySYlyr27yVOj5aVz0e55JePO+kELIvfdQ==
+  dependencies:
+    "@intlify/shared" "11.1.12"
+    source-map-js "^1.0.2"
+
+"@intlify/message-compiler@11.4.8":
+  version "11.4.8"
+  resolved "https://registry.yarnpkg.com/@intlify/message-compiler/-/message-compiler-11.4.8.tgz#4f8ef43a1076899102335d456f8309d3c1666510"
+  integrity sha512-vbzk17dYwduYiv52EK61+FDCyhfVg1uPUtPmiD/d45W99uJIcXywrweOBcHv7n9/iEqmXiMGT52bgJbZDQqK3w==
+  dependencies:
+    "@intlify/shared" "11.4.8"
+    source-map-js "^1.0.2"
+
+"@intlify/shared@11.1.12":
+  version "11.1.12"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.1.12.tgz#ab41083e017d622cf63c7dc88a0ee0bc27f4127a"
+  integrity sha512-Om86EjuQtA69hdNj3GQec9ZC0L0vPSAnXzB3gP/gyJ7+mA7t06d9aOAiqMZ+xEOsumGP4eEBlfl8zF2LOTzf2A==
+
+"@intlify/shared@11.4.8":
+  version "11.4.8"
+  resolved "https://registry.yarnpkg.com/@intlify/shared/-/shared-11.4.8.tgz#3c62c7882d07f4ab0f909760308accdc1465ea3d"
+  integrity sha512-XbRgrv+XEuvDr7UCY55oibVrh+o4u+A0VB6nSL0F5Z8LcZxE/8j573LYG6bCrOigIcHdGpSNI7Rh5UpC5/B/eg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1287,6 +1363,17 @@
     estree-walker "^2.0.2"
     source-map-js "^1.2.1"
 
+"@vue/compiler-core@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.5.41.tgz#82a4012d8b420f5a62c1658a72d16f7d1edf11aa"
+  integrity sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==
+  dependencies:
+    "@babel/parser" "^7.29.8"
+    "@vue/shared" "3.5.41"
+    entities "^7.0.1"
+    estree-walker "^2.0.2"
+    source-map-js "^1.2.1"
+
 "@vue/compiler-dom@3.5.25", "@vue/compiler-dom@^3.3.4", "@vue/compiler-dom@^3.5.0":
   version "3.5.25"
   resolved "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.25.tgz"
@@ -1295,7 +1382,30 @@
     "@vue/compiler-core" "3.5.25"
     "@vue/shared" "3.5.25"
 
-"@vue/compiler-sfc@3.5.25", "@vue/compiler-sfc@^3.5.18":
+"@vue/compiler-dom@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz#1029f75de09c665a0a92c6156463754192acb361"
+  integrity sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==
+  dependencies:
+    "@vue/compiler-core" "3.5.41"
+    "@vue/shared" "3.5.41"
+
+"@vue/compiler-sfc@3.5.41", "@vue/compiler-sfc@^3.5.0":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz#f9c7c2170ad6ee4bf35c178b5df026485d8a63db"
+  integrity sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==
+  dependencies:
+    "@babel/parser" "^7.29.8"
+    "@vue/compiler-core" "3.5.41"
+    "@vue/compiler-dom" "3.5.41"
+    "@vue/compiler-ssr" "3.5.41"
+    "@vue/shared" "3.5.41"
+    estree-walker "^2.0.2"
+    magic-string "^0.30.21"
+    postcss "^8.5.19"
+    source-map-js "^1.2.1"
+
+"@vue/compiler-sfc@^3.5.18":
   version "3.5.25"
   resolved "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.25.tgz"
   integrity sha512-PUgKp2rn8fFsI++lF2sO7gwO2d9Yj57Utr5yEsDf3GNaQcowCLKL7sf+LvVFvtJDXUp/03+dC6f2+LCv5aK1ag==
@@ -1318,6 +1428,14 @@
     "@vue/compiler-dom" "3.5.25"
     "@vue/shared" "3.5.25"
 
+"@vue/compiler-ssr@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz#8e5f9f6a8d21b802fce7373807dd935ed4541083"
+  integrity sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==
+  dependencies:
+    "@vue/compiler-dom" "3.5.41"
+    "@vue/shared" "3.5.41"
+
 "@vue/compiler-vue2@^2.7.16":
   version "2.7.16"
   resolved "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz"
@@ -1325,6 +1443,11 @@
   dependencies:
     de-indent "^1.0.2"
     he "^1.2.0"
+
+"@vue/devtools-api@^6.5.0":
+  version "6.6.4"
+  resolved "https://registry.yarnpkg.com/@vue/devtools-api/-/devtools-api-6.6.4.tgz#cbe97fe0162b365edc1dba80e173f90492535343"
+  integrity sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==
 
 "@vue/devtools-core@^7.7.9":
   version "7.7.9"
@@ -1389,43 +1512,49 @@
     muggle-string "^0.4.1"
     path-browserify "^1.0.1"
 
-"@vue/reactivity@3.5.25":
-  version "3.5.25"
-  resolved "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.25.tgz"
-  integrity sha512-5xfAypCQepv4Jog1U4zn8cZIcbKKFka3AgWHEFQeK65OW+Ys4XybP6z2kKgws4YB43KGpqp5D/K3go2UPPunLA==
+"@vue/reactivity@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.5.41.tgz#83be61b88b198f21c157d3aa6dcb843a25a11872"
+  integrity sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==
   dependencies:
-    "@vue/shared" "3.5.25"
+    "@vue/shared" "3.5.41"
 
-"@vue/runtime-core@3.5.25":
-  version "3.5.25"
-  resolved "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.25.tgz"
-  integrity sha512-Z751v203YWwYzy460bzsYQISDfPjHTl+6Zzwo/a3CsAf+0ccEjQ8c+0CdX1WsumRTHeywvyUFtW6KvNukT/smA==
+"@vue/runtime-core@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.5.41.tgz#a3e023c9f21809c81f24813dacb7ffa18a2e4161"
+  integrity sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==
   dependencies:
-    "@vue/reactivity" "3.5.25"
-    "@vue/shared" "3.5.25"
+    "@vue/reactivity" "3.5.41"
+    "@vue/shared" "3.5.41"
 
-"@vue/runtime-dom@3.5.25":
-  version "3.5.25"
-  resolved "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.25.tgz"
-  integrity sha512-a4WrkYFbb19i9pjkz38zJBg8wa/rboNERq3+hRRb0dHiJh13c+6kAbgqCPfMaJ2gg4weWD3APZswASOfmKwamA==
+"@vue/runtime-dom@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz#428f7a0420402385fae17d413d25169f98f64205"
+  integrity sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==
   dependencies:
-    "@vue/reactivity" "3.5.25"
-    "@vue/runtime-core" "3.5.25"
-    "@vue/shared" "3.5.25"
-    csstype "^3.1.3"
+    "@vue/reactivity" "3.5.41"
+    "@vue/runtime-core" "3.5.41"
+    "@vue/shared" "3.5.41"
+    csstype "^3.2.3"
 
-"@vue/server-renderer@3.5.25":
-  version "3.5.25"
-  resolved "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.25.tgz"
-  integrity sha512-UJaXR54vMG61i8XNIzTSf2Q7MOqZHpp8+x3XLGtE3+fL+nQd+k7O5+X3D/uWrnQXOdMw5VPih+Uremcw+u1woQ==
+"@vue/server-renderer@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.5.41.tgz#035a38c79182f154495238ea83acba24266ac200"
+  integrity sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==
   dependencies:
-    "@vue/compiler-ssr" "3.5.25"
-    "@vue/shared" "3.5.25"
+    "@vue/compiler-ssr" "3.5.41"
+    "@vue/runtime-dom" "3.5.41"
+    "@vue/shared" "3.5.41"
 
 "@vue/shared@3.5.25", "@vue/shared@^3.5.0", "@vue/shared@^3.5.18":
   version "3.5.25"
   resolved "https://registry.npmjs.org/@vue/shared/-/shared-3.5.25.tgz"
   integrity sha512-AbOPdQQnAnzs58H2FrrDxYj/TJfmeS2jdfEEhgiKINy+bnOANmVizIEgq1r+C5zsbs6l1CCQxtcj71rwNQ4jWg==
+
+"@vue/shared@3.5.41":
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.5.41.tgz#ac476497f74495f7525087270849841756555cf2"
+  integrity sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==
 
 "@vue/tsconfig@^0.5.1":
   version "0.5.1"
@@ -1788,9 +1917,9 @@ cssesc@^3.0.0:
   resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-csstype@^3.1.3:
+csstype@^3.2.3:
   version "3.2.3"
-  resolved "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
 
 de-indent@^1.0.2:
@@ -1886,6 +2015,11 @@ entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 error-ex@^1.3.1:
   version "1.3.4"
@@ -3152,6 +3286,11 @@ nanoid@^3.3.11:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
 nanoid@^5.1.0:
   version "5.1.6"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz"
@@ -3413,6 +3552,15 @@ postcss@^8.4.43, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+postcss@^8.5.19:
+  version "8.5.26"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -3650,7 +3798,7 @@ slash@^3.0.0:
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
@@ -3976,6 +4124,15 @@ vue-eslint-parser@^9.3.1, vue-eslint-parser@^9.4.3:
     lodash "^4.17.21"
     semver "^7.3.6"
 
+vue-i18n@11.1.12:
+  version "11.1.12"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-11.1.12.tgz#230b21d65dd89343ebd40d19c9e3cfb13db8c1fd"
+  integrity sha512-BnstPj3KLHLrsqbVU2UOrPmr0+Mv11bsUZG0PyCOzsawCivk8W00GMXHeVUWIDOgNaScCuZah47CZFE+Wnl8mw==
+  dependencies:
+    "@intlify/core-base" "11.1.12"
+    "@intlify/shared" "11.1.12"
+    "@vue/devtools-api" "^6.5.0"
+
 vue-tsc@^2.0.11:
   version "2.2.12"
   resolved "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz"
@@ -3984,16 +4141,16 @@ vue-tsc@^2.0.11:
     "@volar/typescript" "2.4.15"
     "@vue/language-core" "2.2.12"
 
-vue@^3.4.27:
-  version "3.5.25"
-  resolved "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz"
-  integrity sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==
+vue@^3.5.0:
+  version "3.5.41"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.5.41.tgz#8864bddfe59ce128a28c9bad219cd9248916af73"
+  integrity sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==
   dependencies:
-    "@vue/compiler-dom" "3.5.25"
-    "@vue/compiler-sfc" "3.5.25"
-    "@vue/runtime-dom" "3.5.25"
-    "@vue/server-renderer" "3.5.25"
-    "@vue/shared" "3.5.25"
+    "@vue/compiler-dom" "3.5.41"
+    "@vue/compiler-sfc" "3.5.41"
+    "@vue/runtime-dom" "3.5.41"
+    "@vue/server-renderer" "3.5.41"
+    "@vue/shared" "3.5.41"
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
## Summary
- add Vue I18n with English and Dutch catalogues
- persist manual language selection with browser-language fallback
- translate settings, controls, help, and accessibility labels
- add locale normalization and catalogue parity tests

## Verification
- yarn type-check
- yarn test
- yarn build